### PR TITLE
#55 - 헤로쿠 DB 변경 (ClearDB-> JawsDB)

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -49,6 +49,6 @@ spring:
 spring:
   config.activate.on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
   jpa.hibernate.ddl-auto: create
   sql.init.mode: always


### PR DESCRIPTION
조사해본 결과, cleardb의 기본 mysql 버전이 `5.6`으로 낮기 때문에 문제가 발생한 것을 확인함.(5.6 버전에서는 `article_comment_content` 인덱스 사이즈가 너무 큼)
대안으로 MySQL `8.0`을 지원하는 JawsDB를 사용. 이를 이용해 환경 변수를 다시 작업함
* https://devcenter.heroku.com/articles/cleardb
* https://devcenter.heroku.com/articles/jawsdb