### PR TITLE
bug fix : article find 버그

### DIFF
--- a/src/main/java/com/example/boardservice/controller/ArticleController.java
+++ b/src/main/java/com/example/boardservice/controller/ArticleController.java
@@ -97,7 +97,6 @@ public class ArticleController {
     @PostMapping("/{articleId}/form")
     public String updateArticle(@PathVariable(name="articleId") Long articleId, ArticleRequest articleRequest,
                     @AuthenticationPrincipal BoardPrincipal boardPrincipal) {
-        // TODO: 인증 정보를 넣어줘야 한다.
         articleService.updateArticle(articleId, articleRequest.toDto(BoardPrincipal.toDto(boardPrincipal))
         );
 

--- a/src/main/java/com/example/boardservice/service/ArticleService.java
+++ b/src/main/java/com/example/boardservice/service/ArticleService.java
@@ -65,7 +65,7 @@ public class ArticleService {
 
     public void updateArticle(Long articleId, ArticleDto dto) {
         try {
-            Article article = articleRepository.getReferenceById(articleId);
+            Article article = articleRepository.findById(articleId).get();
             UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
             if(article.getUserAccount().equals(userAccount)) {
                 if (dto.title() != null) {


### PR DESCRIPTION
ArticleRepository의 getReferenceId를 통해 Article 엔티티를 불러와야하지만 버그로 인해 부모 객체의 값은 저장되어 있지만 구현체에 null로 채워진 값이 들어가진다. 때문에 이를 해결하기 위해findById로 함수를 대체함

this closes #52 