### PR TITLE
#60 - 엔티티 equals(), hashcode() 비교 로직에 getter 적용

### DIFF
--- a/src/main/java/com/example/boardservice/domain/Article.java
+++ b/src/main/java/com/example/boardservice/domain/Article.java
@@ -53,12 +53,12 @@ public class Article extends AuditingFields{
     public boolean equals(Object o) { //id라는 유니크한 속성만으로도 동등한 객체인지에 대한 비교가 충분하기 때문에 id만을 사용하여 성능을 높여줌
         if (this == o) return true;
         if (!(o instanceof Article article)) return false;
-        return id != null &&  id.equals(article.id);
+        return this.getId() != null &&  this.getId().equals(article.id);
         //아직 영속화가 되기 전이면 null일 수 있기 때문에 null check와 동시에 아직 영속화 대상에 포함되지 않는 객체들은 같은 대상으로 보지 않겠다는 의미도 갖고 있음.
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/example/boardservice/domain/ArticleComment.java
+++ b/src/main/java/com/example/boardservice/domain/ArticleComment.java
@@ -41,11 +41,11 @@ public class ArticleComment extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return this.getId() != null && this.getId().equals(that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/example/boardservice/domain/UserAccount.java
+++ b/src/main/java/com/example/boardservice/domain/UserAccount.java
@@ -50,11 +50,11 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null &&userId.equals(userAccount.userId);
+        return this.getUserId() != null && this.getUserId().equals(userAccount.userId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
엔티티의 `equals()`, `hashcode()`가 값 비교를 하기 위해 필드 직접 접근을 하는 것을 getter 접근으로 바꾼다.
프록시 객체를 사용하는 하이버네이트의 지연 로딩을 고려하여, 값 비교를 제대로 수행하지 못하는 일이 없도록 한다.

this closes #60 