### PR TITLE
#67 - 첫 로그인 시 리다이렉션 문제 해결

### DIFF
--- a/src/main/java/com/example/boardservice/config/SecurityConfig.java
+++ b/src/main/java/com/example/boardservice/config/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET,
                                 "/"
                                 , "/articles"
-                                ,"/articles/search-hashtag").permitAll()
+                                ,"/articles/search-hashtag", "/error").permitAll()
                         .anyRequest().authenticated())
                 .formLogin(Customizer.withDefaults())
                 .logout(logout -> logout.logoutSuccessUrl("/"));


### PR DESCRIPTION
`/error` 에 대한 권한이 없었기 때문에 로그인 페이지에 대한 리다이렉션 과정에서 `/error`에 대한 렌더링을 해주지 못하는 문제였던 것으로 보인다.

참고 : https://stackoverflow.com/questions/61029340/spring-security-redirects-to-page-with-status-code-999/61029341