### PR TITLE
게시글 네비게이션 로직 버그 수정

### DIFF
--- a/src/main/java/com/example/boardservice/service/ArticleService.java
+++ b/src/main/java/com/example/boardservice/service/ArticleService.java
@@ -40,7 +40,9 @@ public class ArticleService {
         if (searchKeyword == null || searchKeyword.isBlank()) {
             return articleRepository.findAll(pageable).map(ArticleDto::from);
         }
-
+        if(searchType == SearchType.HASHTAG && pageable.getSort().getOrderFor(searchType.name().toLowerCase() + 's') != null){
+            return articleRepository.findAll(pageable).map(ArticleDto::from);
+        }
         return switch (searchType) {
             case TITLE ->
                     articleRepository.findByTitleContainingIgnoreCase(searchKeyword, pageable).map(ArticleDto::from);

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -64,19 +64,19 @@
         <attr sel="#pagination">
             <attr sel="li[0]/a"
                   th:text="'previous'"
-                  th:href="@{/articles(page=${articles.number - 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+                  th:href="@{/articles(page=${articles.number - 1}, sort=${param.sort}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
                   th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
             />
             <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
                 <attr sel="a"
                       th:text="${pageNumber + 1}"
-                      th:href="@{/articles(page=${pageNumber}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+                      th:href="@{/articles(page=${pageNumber}, sort=${param.sort}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
                       th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
                 />
             </attr>
             <attr sel="li[2]/a"
                   th:text="'next'"
-                  th:href="@{/articles(page=${articles.number + 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+                  th:href="@{/articles(page=${articles.number + 1},sort=${param.sort}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
                   th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
             />
         </attr>


### PR DESCRIPTION
해당 pr은 현재 버전에서 존재하는 아래의 2가지 bug를 해결함.

* 게시글을 특정 hashtag로 list를 뽑은 뒤 해당 특정 hashtag들 사이에서 정렬을 시도할 때 다시 한번 해시태그를 순서대로 정렬하려고 하면 에러페이지가 출력됨.
* previous 버튼과 next버튼을 누를 경우 기존 정렬 순서가 풀림

this closes #83 