### PR TITLE
[버그] 게시글 갱신 기능 장애 대응

### DIFF
--- a/src/main/java/com/example/boardservice/service/ArticleService.java
+++ b/src/main/java/com/example/boardservice/service/ArticleService.java
@@ -96,7 +96,7 @@ public class ArticleService {
 
     public void updateArticle(Long articleId, ArticleDto dto) {
         try {
-            Article article = articleRepository.getReferenceById(articleId);
+            Article article = articleRepository.findById(articleId).get();
             UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
             if (article.getUserAccount().equals(userAccount)) {
                 if (dto.title() != null) {


### PR DESCRIPTION
단순히 getReferenceById와 findById의 차이로 인한 업데이트 오류라기 보단. lazyloading 상황에서  transaction 으로 묶였을 때 영속성 컨텍스트가  DB에 변경점을 반영 안해주는 현상이 있는 것 같다.

그것이 아니라면 원인을 발견하지 못하겠다. (8시간을 찾아봐도 원인을 찾지 못했다.)