### PR TITLE
API 호출이 가능하도록 인증 설정 변경하기

### DIFF
--- a/src/main/java/com/example/boardservice/config/SecurityConfig.java
+++ b/src/main/java/com/example/boardservice/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests(auth-> auth
                         .requestMatchers( PathRequest.toStaticResources().atCommonLocations()).permitAll() //정적 자원에 대한 보안 요소를 Spring Security 관리하에 두도록 한다.
+                        .requestMatchers("/api/**").permitAll()
                         .requestMatchers( HttpMethod.GET,
                                 "/"
                                 , "/articles"
@@ -39,6 +40,7 @@ public class SecurityConfig {
                         .anyRequest().authenticated())
                 .formLogin(withDefaults())
                 .logout(logout -> logout.logoutSuccessUrl("/"))
+                .csrf(csrf -> csrf.ignoringRequestMatchers("/api/**"))
                 .oauth2Login(oAuth -> oAuth
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(oAuth2UserService)


### PR DESCRIPTION
어드민 서비스에서 원활하게 게시판 서비스의 데이터 api를 이용할 수 있도록 시큐리티 설정을 업데이트 한다.

this closes #103 